### PR TITLE
Upload Build Artifacts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,3 +22,8 @@ jobs:
       run: cd ./iris && ./gradlew publishToMavenLocal && cd ..
     - name: Build artifacts
       run: ./gradlew build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: build-artifacts
+        path: build/libs


### PR DESCRIPTION
Changed GitHub Actions to upload Build Artifacts.
This makes it more convenient to get updates (not having to compile after every single commit)